### PR TITLE
Add backdrop for floating menu in Mobile View

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -51,7 +51,7 @@ export default async function LocaleLayout({
 
   return (
     <html className="h-full scroll-smooth" lang={locale}>
-      <body className={clsx(roboto.className, 'relative flex h-full flex-col bg-black text-white pt-8')}>
+      <body className={clsx(roboto.className, 'relative flex h-full flex-col bg-black text-white pt-10')}>
         <NextIntlClientProvider locale={locale} messages={messages}>
           <Header />
           <MobileHeader />

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -30,6 +30,7 @@ export default function IndexPage() {
           highlight: (chunks) => <span className='text-accent'>{chunks}</span>
         })}
         subtitle={t('ServicesSection.subtitle')}
+        className='scroll-mt-12 min-[920px]:scroll-mt-0'
       >
         <ServicesContent />
       </Section>
@@ -41,7 +42,7 @@ export default function IndexPage() {
           highlight: (chunks) => <span className='text-accent'>{chunks}</span>
         })}
         subtitle={t('TeamSection.subtitle')}
-        className='bg-dark-gray'
+        className='bg-dark-gray scroll-mt-12 min-[920px]:scroll-mt-0'
       >
         <div></div>
       </Section> 

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -26,7 +26,7 @@
       border-image-repeat: stretch stretch;
     }
 
-/*   &::before {
+    /*   &::before {
       content: "";
       position: absolute;
       top: -1rem;
@@ -138,10 +138,10 @@
   }
 
   .navbar--small {
-    @apply fixed z-10 -top-full inset-x-0 py-6 bg-black transition-all duration-300;
+    @apply fixed -top-full inset-x-0 py-6 bg-black transition-all duration-300;
 
     &-open {
-      @apply top-[75px] h-full bg-gradient-to-b from-black to-dark-gray-light;
+      @apply top-[85px] bg-black;
     }
 
     & .nav--link {

--- a/src/components/HeaderMobile.tsx
+++ b/src/components/HeaderMobile.tsx
@@ -41,7 +41,12 @@ export default function MobileHeader() {
             onClick={toggleMenuState}
           />
         </div>
-
+        {openMenu && (
+          <div
+            aria-hidden="true"
+            className="absolute w-full h-screen inset-0 -z-10 bg-black opacity-60"
+          />
+        )}
       </div>
     </header>
   );

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -15,12 +15,16 @@ export default function Section({
   return (
     <section id={id} className={clsx('py-20', className)}>
       <div className='container'>
-        <h2 className='font-bold sec-heading text-balance leading-9 lg:leading-normal'>
-          {title}
-        </h2>
-        <h3 className='font-light sec-subtitle text-balance mt-2 mb-10 lg:mb-16'>
-          {subtitle}
-        </h3>
+        {title && (
+          <h2 className='font-bold sec-heading text-balance leading-9 lg:leading-normal'>
+            {title}
+          </h2>
+        )}
+        {subtitle && (
+          <h3 className='font-light sec-subtitle text-balance mt-2 mb-10 lg:mb-16'>
+            {subtitle}
+          </h3>
+        )}
         {children}
       </div>
     </section>


### PR DESCRIPTION

## Changes

- Implemented a backdrop for the floating menu in the mobile view to enhance visual clarity and focus when the menu is active.

## Test steps

- [x] Verify that the backdrop is appropriately displayed when the floating menu is active.
- [x] Verify that the backdrop enhances the visibility and usability of the menu.
