### PR TITLE
Add width and height to Figures in Expertise and Services content

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -110,7 +110,6 @@
           transform 200ms 200ms cubic-bezier(0.23, 1, 0.32, 1);
       }
     }
-
   }
 
   .navbar--default {
@@ -138,10 +137,10 @@
   }
 
   .navbar--small {
-    @apply fixed -top-full inset-x-0 py-6 bg-black transition-all duration-300;
+    @apply fixed -top-full inset-x-0 py-8 bg-black transition-all duration-300;
 
     &-open {
-      @apply top-[85px] bg-black;
+      @apply top-[80px] bg-black;
     }
 
     & .nav--link {

--- a/src/components/ExpertiseSection.tsx
+++ b/src/components/ExpertiseSection.tsx
@@ -16,6 +16,8 @@ export default function ExpertiseContent() {
         src={ASSETS.ExpertiseSection[key].imageSrc}
         alt={`${key} thumbnail`}
         className='mb-4 lg:my-8'
+        width={480}
+        height={480}
       />
 
       <p className='text-lg font-light text-justify'>

--- a/src/components/HeaderMobile.tsx
+++ b/src/components/HeaderMobile.tsx
@@ -28,7 +28,7 @@ export default function MobileHeader() {
   useClickOutside(menuRef, closeMenu);
 
   return (
-    <header className='fixed z-10 w-full top-0 min-[920px]:hidden pt-6 pb-3 bg-black'>
+    <header className='fixed z-10 w-full top-0 min-[920px]:hidden pt-6 pb-4 bg-black'>
       <div className='container flex items-center justify-between'>
         <Logotype small />
 

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -13,11 +13,19 @@ export default function ServicesContent() {
   const renderedContent = keys.map((key) => (
     <div key={key} className='w-[80%] md:w-[42%] min-[1200px]:w-[30%] xl:mb-0 xl:w-[25%]'>
       <div className='flex flex-col h-full text-center'>
+        {/*
+         * Specify the width and height attributes to enable Next.js to allocate space
+         * for images, ensuring the total height of the viewport is accurately recalculated. 
+         * This prevents anchor links from redirecting to incorrect sections of the page.
+         * Applies for ExpertiseSection 
+         */}
         <Figure
           key={key}
           src={ASSETS.ServicesSection[key].imageSrc}
           alt={`${key} thumbnail`}
           className='mb-4 lg:my-8'
+          width={480}
+          height={480}
         />
 
         <p className='text-3xl font-bold mb-5'>


### PR DESCRIPTION
## Summary

Specify the width and height attributes for the Figure Component in the Expertise and Services sections to enable Next.js to allocate space for images, ensuring the total height of the viewport is accurately recalculated. This precautionary measure helps prevent anchor links from redirecting to incorrect sections of the page. 